### PR TITLE
Add commands to start/stop/clear the scene

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
         "command": "vscode-manim.previewSelection",
         "title": "Preview selected Manim code",
         "category": "Manim"
+      },
+      {
+        "command": "vscode-manim.runScene",
+        "title": "Run scene up to the current line number",
+        "category": "Manim"
       }
     ],
     "keybindings": [
@@ -44,6 +49,12 @@
         "key": "ctrl+' ctrl+r",
         "mac": "cmd+' cmd+r",
         "when": "editorTextFocus"
+      },
+      {
+        "command": "vscode-manim.runScene",
+        "key": "ctrl+shift+' ctrl+shift+r",
+        "mac": "cmd+shift+' cmd+shift+r",
+        "when": "editorTextFocus || terminalFocus"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,18 @@
         "category": "Manim"
       },
       {
-        "command": "vscode-manim.runScene",
-        "title": "Run scene up to the current line number",
+        "command": "vscode-manim.startScene",
+        "title": "Start the scene (in the state between the cursor's and the next line)",
+        "category": "Manim"
+      },
+      {
+        "command": "vscode-manim.exitScene",
+        "title": "Close the animation window and the IPython terminal",
+        "category": "Manim"
+      },
+      {
+        "command": "vscode-manim.clearScene",
+        "title": "Remove all objects from the current scene",
         "category": "Manim"
       }
     ],
@@ -51,10 +61,20 @@
         "when": "editorTextFocus"
       },
       {
-        "command": "vscode-manim.runScene",
-        "key": "ctrl+shift+' ctrl+shift+r",
-        "mac": "cmd+shift+' cmd+shift+r",
-        "when": "editorTextFocus || terminalFocus"
+        "command": "vscode-manim.startScene",
+        "key": "ctrl+' ctrl+s",
+        "mac": "cmd+' cmd+s",
+        "when": "(editorTextFocus || terminalFocus) && editorLangId == 'python'"
+      },
+      {
+        "command": "vscode-manim.exitScene",
+        "key": "ctrl+' ctrl+w",
+        "mac": "cmd+' cmd+w"
+      },
+      {
+        "command": "vscode-manim.clearScene",
+        "key": "ctrl+' ctrl+c",
+        "mac": "cmd+' cmd+c"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -33,17 +33,17 @@
       },
       {
         "command": "manim-notebook.startScene",
-        "title": "Start the scene (in the state between the cursor's and the next line)",
+        "title": "Start scene at cursor",
         "category": "Manim Notebook"
       },
       {
         "command": "manim-notebook.exitScene",
-        "title": "Close the animation window and the IPython terminal",
+        "title": "Quit preview",
         "category": "Manim Notebook"
       },
       {
         "command": "manim-notebook.clearScene",
-        "title": "Remove all objects from the current scene",
+        "title": "Remove all objects from scene",
         "category": "Manim Notebook"
       }
     ],

--- a/src/executeTerminalCommand.ts
+++ b/src/executeTerminalCommand.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+
+/**
+ * Execute the given command in the VSCode terminal:
+ * - either using shell integration (if supported),
+ * - otherwise using `sendText`.
+ * 
+ * @param command The command to execute in the VSCode terminal.
+ */
+export function executeTerminalCommand(command: string): void {
+    // See the new Terminal shell integration API (from VSCode release 1.93)
+    // https://code.visualstudio.com/updates/v1_93#_terminal-shell-integration-api
+    const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
+    if (terminal.shellIntegration) {
+        terminal.shellIntegration.executeCommand(command);
+    } else {
+        terminal.sendText(command);
+    }
+}

--- a/src/executeTerminalCommand.ts
+++ b/src/executeTerminalCommand.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 /**
- * Execute the given command in the VSCode terminal:
+ * Executes the given command in the VSCode terminal:
  * - either using shell integration (if supported),
  * - otherwise using `sendText`.
  * 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,16 +16,30 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	);
 
-	const runSceneCommand = vscode.commands.registerCommand(
-		'vscode-manim.runScene', () => {
-			runScene();
+	const startSceneCommand = vscode.commands.registerCommand(
+		'vscode-manim.startScene', () => {
+			startScene();
+		}
+	);
+
+	const exitSceneCommand = vscode.commands.registerCommand(
+		'vscode-manim.exitScene', () => {
+			exitScene();
+		}
+	);
+
+	const clearSceneCommand = vscode.commands.registerCommand(
+		'vscode-manim.clearScene', () => {
+			clearScene();
 		}
 	);
 
 	context.subscriptions.push(
 		previewManimCellCommand,
 		previewSelectionCommand,
-		runSceneCommand
+		startSceneCommand,
+		exitSceneCommand,
+		clearSceneCommand
 	);
 	registerManimCellProviders(context);
 }
@@ -104,23 +118,27 @@ function previewSelection() {
  * manimgl <file_name> <ClassName> [-se <line_number>]
  * 
  * Notes:
- * - it loads the scene as it would be AFTER this line
+ * - it saves the active file
+ * - it loads the scene in the state it would be BETWEEN the cursor's line and the next line
  * - if the cursor is on a class definition line, `-se <line_number>` is NOT added (i.e. it loads the whole scene)
- * - also copies that command to the clipboard with additional args: `--prerun --finder -w`
+ * - (3b1b's version also copied this command to the clipboard with additional args `--prerun --finder -w`)
  */
-async function runScene() {
+async function startScene() {
 	const editor = vscode.window.activeTextEditor;
 	if (!editor) {
-		vscode.window.showErrorMessage('Editor not found');
+		vscode.window.showErrorMessage(
+			'No opened file found. Please place your cursor at a line of code.'
+		);
 		return;
 	}
 
 	// Save the active file:
 	vscode.commands.executeCommand('workbench.action.files.save');
 
-	const file_path = editor.document.fileName;  // absolute path
-	if (!file_path.endsWith('.py')) {
-		vscode.window.showErrorMessage('Check failed: file must end with .py');
+	// Just in case:
+	const languageId = editor.document.languageId;
+	if (languageId !== 'python') {
+		vscode.window.showErrorMessage('File must be in Python');
 		return;
 	}
 
@@ -128,41 +146,56 @@ async function runScene() {
 	const all_lines = contents.split("\n");
 
 	// Find which lines define classes
-	const class_lines = all_lines  // E.g., class_lines = [{ line: "class FirstScene(Scene):", index: 3 }, ...]
+	// E.g. here, class_lines = [{ line: "class FirstScene(Scene):", index: 3 }, ...]
+	const class_lines = all_lines
 		.map((line, index) => ({ line, index }))
 		.filter(({ line }) => /^class (.+?)\((.+?)\):/.test(line));
 
-	// Where is the cursor (row = line)
+	// Where the cursor is (row = line)
 	const row = editor.selection.start.line;
 
 	// Find the first class defined before where the cursor is
-	const matching_class = class_lines  // E.g., matching_class = { line: "class SelectedScene(Scene):", index: 42 }
+	// E.g. here, matching_class = { line: "class SelectedScene(Scene):", index: 42 }
+	const matching_class = class_lines
 		.reverse()
 		.find(({ index }) => index <= row);
 	if (!matching_class) {
-		vscode.window.showErrorMessage('No matching classes');
+		vscode.window.showErrorMessage('No class found for the cursor position.');
 		return;
 	}
-	const scene_name = matching_class.line.slice("class ".length, matching_class.line.indexOf("("));  // E.g., scene_name = "SelectedScene"
+	// E.g. here, scene_name = "SelectedScene"
+	const scene_name = matching_class.line.slice("class ".length, matching_class.line.indexOf("("));
+
+	// While line is empty - make it the previous line
+	// (because `manimgl -se <line_number>` doesn't work on empty lines)
+	let line_number = row;
+	while (all_lines[line_number].trim() === "") {
+		line_number--;
+	}
 
 	// Create the command
+	const file_path = editor.document.fileName;  // absolute path
 	const cmds = ["manimgl", file_path, scene_name];
 	let enter = false;
 	if (row !== matching_class.index) {
-		cmds.push(`-se ${row + 1}`);
+		cmds.push(`-se ${line_number + 1}`);
 		enter = true;
 	}
 	const command = cmds.join(" ");
 
-	// If one wants to run it in a different terminal,
-	// it's often to write to a file
-	await vscode.env.clipboard.writeText(command + " --prerun --finder -w");
+	// // Commented out - in case someone would like it.
+	// // For us - we want to NOT overwrite our clipboard.
+	// // If one wants to run it in a different terminal,
+	// // it's often to write to a file
+	// await vscode.env.clipboard.writeText(command + " --prerun --finder -w");
 
 	// Run the command
 	const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
 	terminal.sendText(command);
 
-	// // Focus some windows (ONLY for MacOS because it uses `osascript`!!). Commented out because it's not really needed too much??
+	// // Commented out - in case someone would like it.
+	// // For us - it would require MacOS. Also - the effect is not desired.
+	// // Focus some windows (ONLY for MacOS because it uses `osascript`!)
 	// if (enter) {
 	// 	// Keep cursor where it started (in VSCode)
 	// 	const cmd_focus_vscode = 'osascript -e "tell application \\"Visual Studio Code\\" to activate"';
@@ -172,16 +205,24 @@ async function runScene() {
 	// } else {
 	// 	terminal.show();
 	// }
+}
 
-	// // Info for debugging:
-	// console.log('file_path:', file_path);
-	// console.log('row:', row);
-	// // console.log('contents:', contents);
-	// // console.log('all_lines:', all_lines);
-	// console.log('class_lines:', class_lines);
-	// console.log('matching_class:', matching_class);
-	// console.log('scene_name:', scene_name);
-	// console.log('command:', command);
+/**
+ * Runs the `exit()` command in the terminal.
+ * It closes the animation window and the IPython terminal.
+ */
+function exitScene() {
+	const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
+	terminal.sendText("exit()");
+}
+
+/**
+ * Runs the `clear()` command in the terminal.
+ * It removes all objects from the scene.
+ */
+function clearScene() {
+	const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
+	terminal.sendText("clear()");
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -107,8 +107,6 @@ function previewSelection() {
  * - it loads the scene as it would be AFTER this line
  * - if the cursor is on a class definition line, `-se <line_number>` is NOT added (i.e. it loads the whole scene)
  * - also copies that command to the clipboard with additional args: `--prerun --finder -w`
- * 
- * - this function is only for MacOS (because it uses `osascript` to focus the VSCode window)
  */
 async function runScene() {
 	const editor = vscode.window.activeTextEditor;
@@ -164,7 +162,7 @@ async function runScene() {
 	const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
 	terminal.sendText(command);
 
-	// // Focus some windows (ONLY MacOS). Commented out because it's not really needed too much??
+	// // Focus some windows (ONLY for MacOS because it uses `osascript`!!). Commented out because it's not really needed too much??
 	// if (enter) {
 	// 	// Keep cursor where it started (in VSCode)
 	// 	const cmd_focus_vscode = 'osascript -e "tell application \\"Visual Studio Code\\" to activate"';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { ManimCell } from './manimCell';
 import { ManimCellRanges } from './manimCellRanges';
 import { previewCode } from './previewCode';
+import { executeTerminalCommand } from './executeTerminalCommand';
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -190,12 +191,12 @@ async function startScene() {
 	// await vscode.env.clipboard.writeText(command + " --prerun --finder -w");
 
 	// Run the command
-	const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
-	terminal.sendText(command);
+	executeTerminalCommand(command);
 
 	// // Commented out - in case someone would like it.
 	// // For us - it would require MacOS. Also - the effect is not desired.
 	// // Focus some windows (ONLY for MacOS because it uses `osascript`!)
+	// const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
 	// if (enter) {
 	// 	// Keep cursor where it started (in VSCode)
 	// 	const cmd_focus_vscode = 'osascript -e "tell application \\"Visual Studio Code\\" to activate"';
@@ -212,8 +213,7 @@ async function startScene() {
  * It closes the animation window and the IPython terminal.
  */
 function exitScene() {
-	const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
-	terminal.sendText("exit()");
+	executeTerminalCommand("exit()");
 }
 
 /**
@@ -221,8 +221,7 @@ function exitScene() {
  * It removes all objects from the scene.
  */
 function clearScene() {
-	const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
-	terminal.sendText("clear()");
+	executeTerminalCommand("clear()");
 }
 
 /**

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { window } from 'vscode';
+import { executeTerminalCommand } from './executeTerminalCommand';
 
 const PREVIEW_COMMAND = `\x0C checkpoint_paste()\x1b`;
 // \x0C: is Ctrl + L
@@ -47,14 +48,7 @@ export async function previewCode(code: string): Promise<void> {
         await vscode.env.clipboard.writeText(code);
 
         // Send command to interactive IPython shell
-        // See the new Terminal shell integration API (from VSCode release 1.93)
-        // https://code.visualstudio.com/updates/v1_93#_terminal-shell-integration-api
-        const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
-        if (terminal.shellIntegration) {
-            terminal.shellIntegration.executeCommand(PREVIEW_COMMAND);
-        } else {
-            terminal.sendText(PREVIEW_COMMAND);
-        }
+        executeTerminalCommand(PREVIEW_COMMAND);
 
         // Restore original clipboard content
         const timeout = vscode.workspace.getConfiguration("manim-notebook").clipboardTimeout;

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -47,7 +47,6 @@ export async function previewCode(code: string): Promise<void> {
         const clipboardBuffer = await vscode.env.clipboard.readText();
         await vscode.env.clipboard.writeText(code);
 
-        // Send command to interactive IPython shell
         executeTerminalCommand(PREVIEW_COMMAND);
 
         // Restore original clipboard content


### PR DESCRIPTION
This PR adds the following commands
- `Start scene at cursor`
- `Quit preview`
- `Remove all objects from scene`

To start the scene, the `manimgl` command is run in the terminal with its current line number

```
manimgl <file_name> <ClassName> [-se <line_number>]
```

Users can use it to start their manim session:
They place the cursor -> run this command -> manim starts in this scene, animation state is already at the point where the cursor is.

---

Note that 3b1b's name for the `runScene` command is `manim_run_scene` as found [here](https://github.com/3b1b/videos/blob/4203c7a9a54842b98c943d7d8f5d85dea330c543/sublime_custom_commands/manim_plugins.py#L123)