### PR TITLE
Init logging mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ If you encounter an issue, search for some related keywords first in the [issues
 - Now reproduce the issue, e.g. by running a command that causes the problem.
 - Open the command palette again and use the command `Manim Notebook: Open Log File`.
 - Attach the log file to your GitHub issue. To do so, right-click on the opened log file header (the tab pane that shows the filename at the top of the editor) and select `Reveal In File Explorer` (or `Reveal in Finder`). Then drag and drop the file into the GitHub issue text field.
+- Last, but not least, don't forget to set the log level back to `Info` to avoid performance issues. `Developer: Set Log Level...` -> `Manim Notebook` -> `Info`.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ The resulting workflow can look like Grant's 🥳
 - [contributing](https://github.com/bhoov/manim-notebook/blob/main/CONTRIBUTING.md)
 
 - [wiki](https://github.com/bhoov/manim-notebook/wiki)
+
+<br /><br />
+
+## Troubleshooting
+
+If you encounter an issue, search for some related keywords first in the [issues](https://github.com/bhoov/manim-notebook/issues). If you can't find anything, feel free to open a new issue. To analyze the problem, we need a **log file** from you:
+
+- Reload the VSCode window. This is important for us such that only important log messages are included in the log file and not unrelated ones.
+- Open the command palette (`Ctrl+Shift+P` or `Cmd+Shift+P`). Use the command `Developer: Set Log Level...`, click on `Manim Notebook` and set the log level to `Trace`.
+- Now reproduce the issue, e.g. by running a command that causes the problem.
+- Open the command palette again and use the command `Manim Notebook: Open Log File`.
+- Attach the log file to your GitHub issue. To do so, right-click on the opened log file header (the tab pane that shows the filename at the top of the editor) and select `Reveal In File Explorer`. Then drag and drop the file into the GitHub issue text field.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
         "command": "manim-notebook.clearScene",
         "title": "Remove all objects from scene",
         "category": "Manim Notebook"
+      },
+      {
+        "command": "manim-notebook.openLogFile",
+        "title": "Open log file",
+        "category": "Manim Notebook"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
       },
       {
         "command": "manim-notebook.openLogFile",
-        "title": "Open log file",
+        "title": "Open Log File",
         "category": "Manim Notebook"
       }
     ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,8 @@ import { ManimCell } from './manimCell';
 import { ManimCellRanges } from './manimCellRanges';
 import { previewCode } from './previewCode';
 import { startScene, exitScene } from './startStopScene';
-import { logger, loggerName } from './logger';
+import { loggerName } from './logger';
+import Logger from './logger';
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -55,6 +56,8 @@ export function activate(context: vscode.ExtensionContext) {
 		openLogFileCommand
 	);
 	registerManimCellProviders(context);
+
+	Logger.info("Manim Notebook activated");
 }
 
 export function deactivate() { }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { ManimCell } from './manimCell';
 import { ManimCellRanges } from './manimCellRanges';
 import { previewCode } from './previewCode';
 import { startScene, exitScene } from './startStopScene';
+import { logger, loggerName } from './logger';
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -40,12 +41,18 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	);
 
+	const openLogFileCommand = vscode.commands.registerCommand(
+		'manim-notebook.openLogFile', async () => {
+			openLogFile(context);
+		});
+
 	context.subscriptions.push(
 		previewManimCellCommand,
 		previewSelectionCommand,
 		startSceneCommand,
 		exitSceneCommand,
-		clearSceneCommand
+		clearSceneCommand,
+		openLogFileCommand
 	);
 	registerManimCellProviders(context);
 }
@@ -166,4 +173,35 @@ function registerManimCellProviders(context: vscode.ExtensionContext) {
 	if (window.activeTextEditor) {
 		manimCell.applyCellDecorations(window.activeTextEditor);
 	}
+}
+
+/**
+ * Opens the Manim Notebook log file in a new editor.
+ * 
+ * @param context The extension context.
+ */
+function openLogFile(context: vscode.ExtensionContext) {
+	const logFilePath = vscode.Uri.joinPath(context.logUri, `${loggerName}.log`);
+	vscode.window.withProgress({
+		location: vscode.ProgressLocation.Notification,
+		title: "Opening Manim Notebook log file...",
+		cancellable: false
+	}, async (progressIndicator, token) => {
+		await new Promise<void>(async (resolve) => {
+			try {
+				const doc = await vscode.workspace.openTextDocument(logFilePath);
+				await vscode.window.showTextDocument(doc);
+			} catch {
+				vscode.window.showErrorMessage("Could not open Manim Notebook log file");
+			} finally {
+				resolve();
+			}
+
+			// I've also tried to open the log file in the OS browser,
+			// but didn't get it to work via:
+			// commands.executeCommand("revealFileInOS", logFilePath);
+			// For a sample usage, see this:
+			// https://github.com/microsoft/vscode/blob/9de080f7cbcec77de4ef3e0d27fbf9fd335d3fba/extensions/typescript-language-features/src/typescriptServiceClient.ts#L580-L586
+		});
+	});
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,79 @@
 import { window } from 'vscode';
+import * as path from 'path';
 
 export const loggerName = 'Manim Notebook';
-export const logger = window.createOutputChannel(loggerName, { log: true });
+const logger = window.createOutputChannel(loggerName, { log: true });
+
+export default class Logger {
+
+    public static trace(message: string) {
+        logger.trace(`${Logger.getFormattedCallerInformation()} ${message}`);
+    }
+
+    public static debug(message: string) {
+        logger.debug(`${Logger.getFormattedCallerInformation()} ${message}`);
+    }
+
+    public static info(message: string) {
+        logger.info(`${Logger.getFormattedCallerInformation()} ${message}`);
+    }
+
+    public static warn(message: string) {
+        logger.warn(`${Logger.getFormattedCallerInformation()} ${message}`);
+    }
+
+    public static error(message: string) {
+        logger.error(`${Logger.getFormattedCallerInformation()} ${message}`);
+    }
+
+    /**
+     * Returns formatted caller information in the form of
+     * "[filename] [methodname]".
+     * 
+     * It works by creating a stack trace and extracting the file name from the
+     * third line of the stack trace, e.g.
+     * 
+     * Error:
+     *      at Logger.getCurrentFileName (manim-notebook/out/logger.js:32:19)
+     *      at Logger.info (manim-notebook/out/logger.js:46:39)
+     *      at activate (manim-notebook/out/extension.js:37:21)
+     * ...
+     * 
+     * where "extension.js" is the file that called the logger method
+     * and "activate" is the respective method.
+     */
+    private static getFormattedCallerInformation(): string {
+        const error = new Error();
+        const stack = error.stack;
+
+        const unknownString = "[unknown] [unknown]";
+
+        if (!stack) {
+            return unknownString;
+        }
+
+        const stackLines = stack.split('\n');
+        if (stackLines.length < 4) {
+            return unknownString;
+        }
+
+        const callerLine = stackLines[3];
+        if (!callerLine) {
+            return unknownString;
+        }
+
+        const methodMatch = callerLine.match(/at (\w+) \(/);
+        let methodName = 'unknown';
+        if (methodMatch && methodMatch[1]) {
+            methodName = methodMatch[1];
+        }
+
+        const fileMatch = callerLine.match(/\((.*):\d+:\d+\)/);
+        let fileName = 'unknown';
+        if (fileMatch && fileMatch[1]) {
+            fileName = path.basename(fileMatch[1]);
+        }
+
+        return `[${fileName}] [${methodName}]`;
+    }
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -39,8 +39,18 @@ export default class Logger {
      *      at activate (manim-notebook/out/extension.js:37:21)
      * ...
      * 
-     * where "extension.js" is the file that called the logger method
+     * where "extension.js:37:21" is the file that called the logger method
      * and "activate" is the respective method.
+     * 
+     * Another example where the Logger is called in a Promise might be:
+     * 
+     * Error:
+     *     at Function.getFormattedCallerInformation (manim-notebook/src/logger.ts:46:23)
+     *     at Function.info (manim-notebook/src/logger.ts:18:31)
+     *     at manim-notebook/src/extension.ts:199:12
+     * 
+     * where "extension.ts:199:12" is the file that called the logger method
+     * and the method is unknown.
      */
     private static getFormattedCallerInformation(): string {
         const error = new Error();
@@ -62,16 +72,16 @@ export default class Logger {
             return unknownString;
         }
 
+        const fileMatch = callerLine.match(/(?:[^\(\s][\S])*:\d+:\d+/);
+        let fileName = 'unknown';
+        if (fileMatch && fileMatch[0]) {
+            fileName = path.basename(fileMatch[0]);
+        }
+
         const methodMatch = callerLine.match(/at (\w+) \(/);
         let methodName = 'unknown';
         if (methodMatch && methodMatch[1]) {
             methodName = methodMatch[1];
-        }
-
-        const fileMatch = callerLine.match(/\((.*):\d+:\d+\)/);
-        let fileName = 'unknown';
-        if (fileMatch && fileMatch[1]) {
-            fileName = path.basename(fileMatch[1]);
         }
 
         return `[${fileName}] [${methodName}]`;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,4 @@
+import { window } from 'vscode';
+
+export const loggerName = 'Manim Notebook';
+export const logger = window.createOutputChannel(loggerName, { log: true });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -72,7 +72,7 @@ export default class Logger {
             return unknownString;
         }
 
-        const fileMatch = callerLine.match(/(?:[^\(\s][\S])*:\d+:\d+/);
+        const fileMatch = callerLine.match(/(?:[^\(\s])*?:\d+:\d+/);
         let fileName = 'unknown';
         if (fileMatch && fileMatch[0]) {
             fileName = path.basename(fileMatch[0]);


### PR DESCRIPTION
In this PR, we init the `Logger` class to log to the `Manim Notebook` output pane in VSCode as well as to a dedicated log file. For users to access this log file, we add a `Manim Notebook: Open log file` command. I've also included a section in the Readme explaining how to report an issue using this log file.

As I had to search way too long to find the relevant information on how to log in a VSCode extension, I've also [written a StackOverflow answer](https://stackoverflow.com/questions/55583723/creating-a-log-file-for-a-vscode-extension/79135427#79135427).

A subsequent PR will then add respective `Logger.trace()` etc. statements at important places in the code.


### Known limitations
The line and colon numbers refer to the position in the transpiled `.js`. I haven't yet bothered about generating **source maps** via the TypeScript compiler to then map the positions to those in the original `.ts` file. I don't even know if these maps would get distributed on the VSCode marketplace.

We can still (later on) write a small script for ourselves that takes in a given user log and the Manim Notebook version used, then checks out the respective code on GitHub, generates the source maps and replaces the corresponding line and colon numbers in the log file.