### PR TITLE
Add logging statements all over the place

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,35 +14,41 @@ export function activate(context: vscode.ExtensionContext) {
 
 	const previewManimCellCommand = vscode.commands.registerCommand(
 		'manim-notebook.previewManimCell', (cellCode?: string, startLine?: number) => {
+			Logger.info(`💠 Command requested: Preview Manim Cell, startLine=${startLine}`);
 			previewManimCell(cellCode, startLine);
 		});
 
 	const previewSelectionCommand = vscode.commands.registerCommand(
 		'manim-notebook.previewSelection', () => {
+			Logger.info("💠 Command requested: Preview Selection");
 			previewSelection();
 		}
 	);
 
 	const startSceneCommand = vscode.commands.registerCommand(
 		'manim-notebook.startScene', () => {
+			Logger.info("💠 Command requested: Start Scene");
 			startScene();
 		}
 	);
 
 	const exitSceneCommand = vscode.commands.registerCommand(
 		'manim-notebook.exitScene', () => {
+			Logger.info("💠 Command requested: Exit Scene");
 			exitScene();
 		}
 	);
 
 	const clearSceneCommand = vscode.commands.registerCommand(
 		'manim-notebook.clearScene', () => {
+			Logger.info("💠 Command requested: Clear Scene");
 			clearScene();
 		}
 	);
 
 	const openLogFileCommand = vscode.commands.registerCommand(
 		'manim-notebook.openLogFile', async () => {
+			Logger.info("💠 Command requested: Open Log File");
 			openLogFile(context);
 		});
 
@@ -59,7 +65,9 @@ export function activate(context: vscode.ExtensionContext) {
 	Logger.info("Manim Notebook activated");
 }
 
-export function deactivate() { }
+export function deactivate() {
+	Logger.info("💠 Manim Notebook extension deactivated");
+}
 
 /**
  * Previews the Manim code of the cell where the cursor is placed

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,8 +5,7 @@ import { ManimCell } from './manimCell';
 import { ManimCellRanges } from './manimCellRanges';
 import { previewCode } from './previewCode';
 import { startScene, exitScene } from './startStopScene';
-import { loggerName } from './logger';
-import Logger from './logger';
+import { Logger, Window, loggerName } from './logger';
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -74,7 +73,7 @@ async function previewManimCell(cellCode?: string, startLine?: number) {
 	if (cellCode === undefined) {
 		const editor = window.activeTextEditor;
 		if (!editor) {
-			window.showErrorMessage(
+			Window.showErrorMessage(
 				'No opened file found. Place your cursor in a Manim cell.');
 			return;
 		}
@@ -84,7 +83,7 @@ async function previewManimCell(cellCode?: string, startLine?: number) {
 		const cursorLine = editor.selection.active.line;
 		const range = ManimCellRanges.getCellRangeAtLine(document, cursorLine);
 		if (!range) {
-			window.showErrorMessage('Place your cursor in a Manim cell.');
+			Window.showErrorMessage('Place your cursor in a Manim cell.');
 			return;
 		}
 		cellCode = document.getText(range);
@@ -92,7 +91,7 @@ async function previewManimCell(cellCode?: string, startLine?: number) {
 	}
 
 	if (startLineFinal === undefined) {
-		window.showErrorMessage('Internal error: Line number not found in `previewManimCell()`.');
+		Window.showErrorMessage('Internal error: Line number not found in `previewManimCell()`.');
 		return;
 	}
 
@@ -105,7 +104,7 @@ async function previewManimCell(cellCode?: string, startLine?: number) {
 async function previewSelection() {
 	const editor = window.activeTextEditor;
 	if (!editor) {
-		window.showErrorMessage('Select some code to preview.');
+		Window.showErrorMessage('Select some code to preview.');
 		return;
 	}
 
@@ -125,7 +124,7 @@ async function previewSelection() {
 	}
 
 	if (!selectedText) {
-		window.showErrorMessage('Select some code to preview.');
+		Window.showErrorMessage('Select some code to preview.');
 		return;
 	}
 
@@ -140,7 +139,7 @@ async function clearScene() {
 	try {
 		await ManimShell.instance.executeCommandErrorOnNoActiveSession("clear()");
 	} catch (NoActiveSessionError) {
-		window.showErrorMessage('No active Manim session found to remove objects from.');
+		Window.showErrorMessage('No active Manim session found to remove objects from.');
 	}
 }
 
@@ -185,7 +184,7 @@ function registerManimCellProviders(context: vscode.ExtensionContext) {
  */
 function openLogFile(context: vscode.ExtensionContext) {
 	const logFilePath = vscode.Uri.joinPath(context.logUri, `${loggerName}.log`);
-	vscode.window.withProgress({
+	window.withProgress({
 		location: vscode.ProgressLocation.Notification,
 		title: "Opening Manim Notebook log file...",
 		cancellable: false
@@ -193,9 +192,9 @@ function openLogFile(context: vscode.ExtensionContext) {
 		await new Promise<void>(async (resolve) => {
 			try {
 				const doc = await vscode.workspace.openTextDocument(logFilePath);
-				await vscode.window.showTextDocument(doc);
+				await window.showTextDocument(doc);
 			} catch {
-				vscode.window.showErrorMessage("Could not open Manim Notebook log file");
+				Window.showErrorMessage("Could not open Manim Notebook log file");
 			} finally {
 				resolve();
 			}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -95,17 +95,17 @@ export class Logger {
 export class Window {
 
     public static showInformationMessage(message: string) {
-        Logger.info(message);
+        Logger.info(`💡 ${message}`);
         window.showInformationMessage(message);
     }
 
     public static showWarningMessage(message: string, ...items: string[]) {
-        Logger.warn(message);
+        Logger.warn(`💡 ${message}`);
         window.showWarningMessage(message, ...items);
     }
 
     public static showErrorMessage(message: string) {
-        Logger.error(message);
+        Logger.error(`💡 ${message}`);
         window.showErrorMessage(message);
     }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 export const loggerName = 'Manim Notebook';
 const logger = window.createOutputChannel(loggerName, { log: true });
 
-export default class Logger {
+export class Logger {
 
     public static trace(message: string) {
         logger.trace(`${Logger.getFormattedCallerInformation()} ${message}`);
@@ -85,5 +85,27 @@ export default class Logger {
         }
 
         return `[${fileName}] [${methodName}]`;
+    }
+}
+
+/**
+ * Class that wraps some VSCode window methods to log the messages before
+ * displaying them to the user as a notification.
+ */
+export class Window {
+
+    public static showInformationMessage(message: string) {
+        Logger.info(message);
+        window.showInformationMessage(message);
+    }
+
+    public static showWarningMessage(message: string, ...items: string[]) {
+        Logger.warn(message);
+        window.showWarningMessage(message, ...items);
+    }
+
+    public static showErrorMessage(message: string) {
+        Logger.error(message);
+        window.showErrorMessage(message);
     }
 }

--- a/src/manimCell.ts
+++ b/src/manimCell.ts
@@ -38,11 +38,11 @@ export class ManimCell implements vscode.CodeLensProvider, vscode.FoldingRangePr
     }
 
     public resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken): vscode.CodeLens {
-        if (!vscode.window.activeTextEditor) {
+        if (!window.activeTextEditor) {
             return codeLens;
         }
 
-        const document = vscode.window.activeTextEditor?.document;
+        const document = window.activeTextEditor?.document;
         const range = new vscode.Range(codeLens.range.start, codeLens.range.end);
         const cellCode = document.getText(range);
 

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -511,7 +511,7 @@ export class ManimShell {
             async (event: vscode.TerminalShellExecutionStartEvent) => {
                 const stream = event.execution.read();
                 for await (const data of withoutAnsiCodes(stream)) {
-                    Logger.trace(`🧾: ${data}`);
+                    Logger.trace(`🧾 Terminal data:\n${data}`);
 
                     this.eventEmitter.emit(ManimShellEvent.DATA, data);
 

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -472,7 +472,11 @@ export class ManimShell {
             this.eventEmitter.once(ManimShellEvent.KEYBOARD_INTERRUPT, resolve);
 
             const listener = () => {
+                Logger.debug("🕒 While waiting for command to finish"
+                    + `, iPythonCellCount=${this.iPythonCellCount}`
+                    + `, currentExecutionCount=${currentExecutionCount}`);
                 if (this.iPythonCellCount > currentExecutionCount) {
+                    Logger.debug("🕒 Command has finished");
                     this.eventEmitter.off(ManimShellEvent.IPYTHON_CELL_FINISHED, listener);
                     resolve();
                 }
@@ -480,6 +484,7 @@ export class ManimShell {
             this.eventEmitter.on(ManimShellEvent.IPYTHON_CELL_FINISHED, listener);
         });
         if (callback) {
+            Logger.debug("🕒 Calling callback after command has finished");
             callback();
         }
     }

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -517,8 +517,8 @@ export class ManimShell {
 
                     if (data.match(MANIM_WELCOME_REGEX)) {
                         if (this.activeShell && this.activeShell !== event.terminal) {
-                            Logger.debug("Manim detected in new terminal, exiting old scene");
-                            exitScene(); // Manim detected in new terminal
+                            Logger.debug("👋 Manim detected in new terminal, exiting old scene");
+                            exitScene();
                         }
                         Logger.debug("👋 Manim welcome string detected");
                         this.activeShell = event.terminal;

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -321,6 +321,7 @@ export class ManimShell {
                         return;
                     }
                 }
+                Logger.debug("🔆 User confirmed to kill active scene");
                 exitScene();
             }
             this.activeShell = window.createTerminal();
@@ -355,7 +356,7 @@ export class ManimShell {
     * command execution.
     */
     public resetActiveShell() {
-        Logger.debug("Reset active shell");
+        Logger.debug("💫 Reset active shell");
         this.iPythonCellCount = 0;
         this.activeShell = null;
         this.shellWeTryToSpawnIn = null;
@@ -417,6 +418,8 @@ export class ManimShell {
      */
     private exec(shell: Terminal, command: string) {
         this.detectShellExecutionEnd = false;
+        Logger.debug("🔒 Shell execution end detection disabled");
+
         if (shell.shellIntegration) {
             Logger.debug(`💨 Sending command to terminal (with shell integration): ${command}`);
             shell.shellIntegration.executeCommand(command);
@@ -424,7 +427,9 @@ export class ManimShell {
             Logger.debug(`💨 Sending command to terminal (without shell integration): ${command}`);
             shell.sendText(command);
         }
+
         this.detectShellExecutionEnd = true;
+        Logger.debug("🔓 Shell execution end detection re-enabled");
     }
 
     /**
@@ -548,7 +553,7 @@ export class ManimShell {
                 }
 
                 if (!this.detectShellExecutionEnd) {
-                    Logger.debug("🔒 Shell execution end detection disabled");
+                    Logger.debug("🔒 Shell execution end detection disabled while end event fired");
                     return;
                 }
 

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { window } from 'vscode';
 import { ManimShell } from './manimShell';
 import { EventEmitter } from 'events';
+import { Logger } from './logger';
 
 const PREVIEW_COMMAND = `\x0C checkpoint_paste()\x1b`;
 // \x0C: is Ctrl + L

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { ManimShell } from './manimShell';
 import { window } from 'vscode';
+import { ManimShell } from './manimShell';
 import { EventEmitter } from 'events';
 
 const PREVIEW_COMMAND = `\x0C checkpoint_paste()\x1b`;
@@ -77,7 +77,7 @@ class PreviewProgress {
     private animationName: string | undefined;
 
     constructor() {
-        vscode.window.withProgress({
+        window.withProgress({
             location: vscode.ProgressLocation.Notification,
             title: "Previewing Manim",
             cancellable: false

--- a/src/previewCode.ts
+++ b/src/previewCode.ts
@@ -34,6 +34,7 @@ export async function previewCode(code: string, startLine: number): Promise<void
         await ManimShell.instance.executeCommand(
             PREVIEW_COMMAND, startLine, true, {
             onCommandIssued: () => {
+                Logger.debug(`📊 Command issued: ${PREVIEW_COMMAND}. Will restore clipboard`);
                 restoreClipboard(clipboardBuffer);
                 progress = new PreviewProgress();
             },
@@ -122,6 +123,8 @@ class PreviewProgress {
             this.animationName = newAnimName;
         }
 
+        Logger.debug(`📊 Progress: ${this.progress} -> ${newProgress} (${progressIncrement})`);
+
         this.eventEmitter.emit(this.REPORT_EVENT, {
             increment: progressIncrement,
             message: newAnimName
@@ -132,6 +135,7 @@ class PreviewProgress {
      * Finishes the progress notification, i.e. closes the progress bar.
      */
     public finish() {
+        Logger.debug("📊 Finishing progress notification");
         this.eventEmitter.emit(this.FINISH_EVENT);
     }
 

--- a/src/startStopScene.ts
+++ b/src/startStopScene.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ManimShell } from './manimShell';
 import { window } from 'vscode';
+import { Logger, Window } from './logger';
 
 /**
  * Runs the `manimgl` command in the terminal, with the current cursor's line number:
@@ -24,7 +25,7 @@ import { window } from 'vscode';
 export async function startScene(lineStart?: number) {
     const editor = window.activeTextEditor;
     if (!editor) {
-        window.showErrorMessage(
+        Window.showErrorMessage(
             'No opened file found. Please place your cursor at a line of code.'
         );
         return;
@@ -35,7 +36,7 @@ export async function startScene(lineStart?: number) {
 
     const languageId = editor.document.languageId;
     if (languageId !== 'python') {
-        window.showErrorMessage("You don't have a Python file open.");
+        Window.showErrorMessage("You don't have a Python file open.");
         return;
     }
 
@@ -55,7 +56,7 @@ export async function startScene(lineStart?: number) {
         .reverse()
         .find(({ index }) => index <= cursorLine);
     if (!matchingClass) {
-        window.showErrorMessage('Place your cursor in Manim code inside a class.');
+        Window.showErrorMessage('Place your cursor in Manim code inside a class.');
         return;
     }
     // E.g. here, sceneName = "SelectedScene"
@@ -110,7 +111,7 @@ export async function startScene(lineStart?: number) {
 export async function exitScene() {
     try {
         await ManimShell.instance.executeCommandErrorOnNoActiveSession("exit()", false, true);
-    } catch(NoActiveSessionError) {
-        window.showErrorMessage('No active Manim session found to exit.');
+    } catch (NoActiveSessionError) {
+        Window.showErrorMessage('No active Manim session found to exit.');
     }
 }


### PR DESCRIPTION
In #56, we introduced a new logging mechanism. Here, we make use of that to log many important steps in the program, mainly for the `ManimShell` and the code preview. Note that as described in the Readme, the default logging level is `Info`, so adding these `debug` or `trace` logging statements should not be a performance problem.

I've also added a custom `Window` class that we can use (note `W` instead of `w`). Before showing the actual notification to the user, it will also log its message with respective log levels.