### PR TITLE
Init Log Recording sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ If you encounter an issue, search for some related keywords first in the [issues
 - Then set the log level by searching for `Manim Notebook` and selecting `Trace`.
 - Now reproduce the issue, e.g. by running a command that causes the problem or previewing a certain Manim cell etc.
 - Once you're done, click on the button in the status bar (bottom right) to finish recording. The log file will be opened afterwards.
-- Drag-and-drop the log file into the GitHub issue text field (as a _file_, please don't paste the _file content_ as this makes the issues hard to read).
+- Drag-and-drop the log file into the GitHub issue text field (as a _file_, i.e. please don't copy-paste its _content_ because this would make it hard to read).

--- a/README.md
+++ b/README.md
@@ -78,9 +78,8 @@ The resulting workflow can look like Grant's 🥳
 
 If you encounter an issue, search for some related keywords first in the [issues](https://github.com/bhoov/manim-notebook/issues). If you can't find anything, feel free to open a new issue. To analyze the problem, we need a **log file** from you:
 
-- Reload the VSCode window. This is important for us such that only important log messages are included in the log file and not unrelated ones.
-- Open the command palette `Ctrl+Shift+P` (or `Cmd+Shift+P`). Use the command `Developer: Set Log Level...`, click on `Manim Notebook` and set the log level to `Trace`.
-- Now reproduce the issue, e.g. by running a command that causes the problem.
-- Open the command palette again and use the command `Manim Notebook: Open Log File`.
-- Attach the log file to your GitHub issue. To do so, right-click on the opened log file header (the tab pane that shows the filename at the top of the editor) and select `Reveal In File Explorer` (or `Reveal in Finder`). Then drag and drop the file into the GitHub issue text field.
-- Last, but not least, don't forget to set the log level back to `Info` to avoid performance issues. `Developer: Set Log Level...` -> `Manim Notebook` -> `Info`.
+- Open the command palette `Ctrl+Shift+P` (or `Cmd+Shift+P`)<br>and use the command `Manim Notebook: Record Log File`.
+- Then set the log level by searching for `Manim Notebook` and selecting `Trace`.
+- Now reproduce the issue, e.g. by running a command that causes the problem or previewing a certain Manim cell etc.
+- Once you're done, click on the button in the status bar (bottom right) to finish recording. The log file will be opened afterwards.
+- Drag-and-drop the log file into the GitHub issue text field (as a _file_, please don't paste the _file content_ as this makes the issues hard to read).

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
         "category": "Manim Notebook"
       },
       {
-        "command": "manim-notebook.openLogFile",
-        "title": "Open Log File",
+        "command": "manim-notebook.recordLogFile",
+        "title": "Record Log File",
         "category": "Manim Notebook"
       }
     ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import { ManimCell } from './manimCell';
 import { ManimCellRanges } from './manimCellRanges';
 import { previewCode } from './previewCode';
 import { startScene, exitScene } from './startStopScene';
-import { Logger, Window, loggerName, recordLogFile } from './logger';
+import { Logger, Window, recordLogFile, finishRecordingLogFile } from './logger';
 
 export function activate(context: vscode.ExtensionContext) {
 	// Trigger the Manim shell to start listening to the terminal
@@ -48,7 +48,14 @@ export function activate(context: vscode.ExtensionContext) {
 	const recordLogFileCommand = vscode.commands.registerCommand(
 		'manim-notebook.recordLogFile', async () => {
 			Logger.info("💠 Command requested: Record Log File");
-			recordLogFile(context);
+			await recordLogFile(context);
+		});
+
+	// internal command
+	const finishRecordingLogFileCommand = vscode.commands.registerCommand(
+		'manim-notebook.finishRecordingLogFile', async () => {
+			Logger.info("💠 Command requested: Finish Recording Log File");
+			await finishRecordingLogFile(context);
 		});
 
 	context.subscriptions.push(
@@ -57,11 +64,11 @@ export function activate(context: vscode.ExtensionContext) {
 		startSceneCommand,
 		exitSceneCommand,
 		clearSceneCommand,
-		recordLogFileCommand
+		recordLogFileCommand,
+		finishRecordingLogFileCommand
 	);
 	registerManimCellProviders(context);
 
-	Logger.clear(context); // until #58 is fixed
 	Logger.info("Manim Notebook activated");
 	Logger.logSystemInformation();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -209,11 +209,25 @@ function openLogFile(context: vscode.ExtensionContext) {
 				resolve();
 			}
 
-			// I've also tried to open the log file in the OS browser,
-			// but didn't get it to work via:
-			// commands.executeCommand("revealFileInOS", logFilePath);
-			// For a sample usage, see this:
-			// https://github.com/microsoft/vscode/blob/9de080f7cbcec77de4ef3e0d27fbf9fd335d3fba/extensions/typescript-language-features/src/typescriptServiceClient.ts#L580-L586
+			try {
+				await revealFileInOS(logFilePath);
+			} catch (error: any) {
+				window.showErrorMessage(`Could not open Manim Notebook log file in the`
+					+ ` OS file explorer: ${error?.message}`);
+			}
 		});
 	});
+}
+
+/**
+ * Opens a file in the OS file explorer.
+ * 
+ * @param uri The URI of the file to reveal.
+ */
+async function revealFileInOS(uri: vscode.Uri) {
+	if (vscode.env.remoteName === 'wsl') {
+		await vscode.commands.executeCommand('remote-wsl.revealInExplorer', uri);
+	} else {
+		await vscode.commands.executeCommand('revealFileInOS', uri);
+	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,9 +68,6 @@ export function activate(context: vscode.ExtensionContext) {
 		finishRecordingLogFileCommand
 	);
 	registerManimCellProviders(context);
-
-	Logger.info("Manim Notebook activated");
-	Logger.logSystemInformation();
 }
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import { ManimCell } from './manimCell';
 import { ManimCellRanges } from './manimCellRanges';
 import { previewCode } from './previewCode';
 import { startScene, exitScene } from './startStopScene';
-import { Logger, Window, loggerName } from './logger';
+import { Logger, Window, loggerName, recordLogFile } from './logger';
 
 export function activate(context: vscode.ExtensionContext) {
 	// Trigger the Manim shell to start listening to the terminal
@@ -45,10 +45,10 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	);
 
-	const openLogFileCommand = vscode.commands.registerCommand(
-		'manim-notebook.openLogFile', async () => {
-			Logger.info("💠 Command requested: Open Log File");
-			openLogFile(context);
+	const recordLogFileCommand = vscode.commands.registerCommand(
+		'manim-notebook.recordLogFile', async () => {
+			Logger.info("💠 Command requested: Record Log File");
+			recordLogFile(context);
 		});
 
 	context.subscriptions.push(
@@ -57,7 +57,7 @@ export function activate(context: vscode.ExtensionContext) {
 		startSceneCommand,
 		exitSceneCommand,
 		clearSceneCommand,
-		openLogFileCommand
+		recordLogFileCommand
 	);
 	registerManimCellProviders(context);
 
@@ -184,50 +184,5 @@ function registerManimCellProviders(context: vscode.ExtensionContext) {
 
 	if (window.activeTextEditor) {
 		manimCell.applyCellDecorations(window.activeTextEditor);
-	}
-}
-
-/**
- * Opens the Manim Notebook log file in a new editor.
- * 
- * @param context The extension context.
- */
-function openLogFile(context: vscode.ExtensionContext) {
-	const logFilePath = vscode.Uri.joinPath(context.logUri, `${loggerName}.log`);
-	window.withProgress({
-		location: vscode.ProgressLocation.Notification,
-		title: "Opening Manim Notebook log file...",
-		cancellable: false
-	}, async (progressIndicator, token) => {
-		await new Promise<void>(async (resolve) => {
-			try {
-				const doc = await vscode.workspace.openTextDocument(logFilePath);
-				await window.showTextDocument(doc);
-			} catch {
-				Window.showErrorMessage("Could not open Manim Notebook log file");
-			} finally {
-				resolve();
-			}
-
-			try {
-				await revealFileInOS(logFilePath);
-			} catch (error: any) {
-				window.showErrorMessage(`Could not open Manim Notebook log file in the`
-					+ ` OS file explorer: ${error?.message}`);
-			}
-		});
-	});
-}
-
-/**
- * Opens a file in the OS file explorer.
- * 
- * @param uri The URI of the file to reveal.
- */
-async function revealFileInOS(uri: vscode.Uri) {
-	if (vscode.env.remoteName === 'wsl') {
-		await vscode.commands.executeCommand('remote-wsl.revealInExplorer', uri);
-	} else {
-		await vscode.commands.executeCommand('revealFileInOS', uri);
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,6 @@ import { startScene, exitScene } from './startStopScene';
 import { Logger, Window, loggerName } from './logger';
 
 export function activate(context: vscode.ExtensionContext) {
-
 	// Trigger the Manim shell to start listening to the terminal
 	ManimShell.instance;
 
@@ -62,6 +61,7 @@ export function activate(context: vscode.ExtensionContext) {
 	);
 	registerManimCellProviders(context);
 
+	Logger.clear(context); // until #58 is fixed
 	Logger.info("Manim Notebook activated");
 	Logger.logSystemInformation();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import { ManimCell } from './manimCell';
 import { ManimCellRanges } from './manimCellRanges';
 import { previewCode } from './previewCode';
 import { startScene, exitScene } from './startStopScene';
-import { Logger, Window, recordLogFile, finishRecordingLogFile } from './logger';
+import { Logger, Window, LogRecorder } from './logger';
 
 export function activate(context: vscode.ExtensionContext) {
 	// Trigger the Manim shell to start listening to the terminal
@@ -48,14 +48,14 @@ export function activate(context: vscode.ExtensionContext) {
 	const recordLogFileCommand = vscode.commands.registerCommand(
 		'manim-notebook.recordLogFile', async () => {
 			Logger.info("💠 Command requested: Record Log File");
-			await recordLogFile(context);
+			await LogRecorder.recordLogFile(context);
 		});
 
 	// internal command
 	const finishRecordingLogFileCommand = vscode.commands.registerCommand(
 		'manim-notebook.finishRecordingLogFile', async () => {
 			Logger.info("💠 Command requested: Finish Recording Log File");
-			await finishRecordingLogFile(context);
+			await LogRecorder.finishRecordingLogFile(context);
 		});
 
 	context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,9 +63,11 @@ export function activate(context: vscode.ExtensionContext) {
 	registerManimCellProviders(context);
 
 	Logger.info("Manim Notebook activated");
+	Logger.logSystemInformation();
 }
 
 export function deactivate() {
+	Logger.deactivate();
 	Logger.info("💠 Manim Notebook extension deactivated");
 }
 

--- a/src/fileUtil.ts
+++ b/src/fileUtil.ts
@@ -1,0 +1,37 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Waits until a file exists on the disk.
+ * 
+ * By https://stackoverflow.com/a/47764403/
+ * 
+ * @param filePath The path of the file to wait for.
+ * @param timeout The maximum time to wait in milliseconds.
+ */
+export async function waitUntilFileExists(filePath: string, timeout: number): Promise<void> {
+    return new Promise(function (resolve, reject) {
+        const timer = setTimeout(function () {
+            watcher.close();
+            reject();
+        }, timeout);
+
+        fs.access(filePath, fs.constants.R_OK, (err) => {
+            if (!err) {
+                clearTimeout(timer);
+                watcher.close();
+                resolve();
+            }
+        });
+
+        const dir = path.dirname(filePath);
+        const basename = path.basename(filePath);
+        const watcher = fs.watch(dir, function (eventType, filename) {
+            if (eventType === 'rename' && filename === basename) {
+                clearTimeout(timer);
+                watcher.close();
+                resolve();
+            }
+        });
+    });
+}

--- a/src/fileUtil.ts
+++ b/src/fileUtil.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -34,4 +35,17 @@ export async function waitUntilFileExists(filePath: string, timeout: number): Pr
             }
         });
     });
+}
+
+/**
+ * Opens a file in the OS file explorer.
+ * 
+ * @param uri The URI of the file to reveal.
+ */
+export async function revealFileInOS(uri: vscode.Uri) {
+    if (vscode.env.remoteName === 'wsl') {
+        await vscode.commands.executeCommand('remote-wsl.revealInExplorer', uri);
+    } else {
+        await vscode.commands.executeCommand('revealFileInOS', uri);
+    }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -224,6 +224,12 @@ export class LogRecorder {
             'statusBarItem.errorBackground');
 
         Logger.isRecording = true;
+
+        // Right now, there is no way to set the log level programatically.
+        // We can just show the pop-up to do so to users.
+        // see https://github.com/microsoft/vscode/issues/223536
+        await vscode.commands.executeCommand('workbench.action.setLogLevel');
+
         Logger.info("📜 Logfile recording started");
         Logger.logSystemInformation();
         this.recorderStatusBar.show();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -194,6 +194,7 @@ export async function recordLogFile(context: vscode.ExtensionContext) {
     });
 
     Logger.info("📜 Logfile recording started");
+    Logger.logSystemInformation();
     logFileRecordingStatusBar.show();
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -39,8 +39,7 @@ export class Logger {
         try {
             const packageJsonPath = path.join(__dirname, '..', 'package.json');
             const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-            const version = packageJson.version;
-            Logger.info(`Manim notebook version: ${version}`);
+            Logger.info(`Manim notebook version: ${packageJson.version}`);
         } catch (error: Error | unknown) {
             Logger.error("Could not determine Manim notebook version used");
             try {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,35 +1,37 @@
 import { window } from 'vscode';
+import { LogOutputChannel } from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 
 export const loggerName = 'Manim Notebook';
-const logger = window.createOutputChannel(loggerName, { log: true });
 
 export class Logger {
 
+    private static logger: LogOutputChannel = window.createOutputChannel(loggerName, { log: true });
+
     public static trace(message: string) {
-        logger.trace(`${Logger.getFormattedCallerInformation()} ${message}`);
+        this.logger.trace(`${Logger.getFormattedCallerInformation()} ${message}`);
     }
 
     public static debug(message: string) {
-        logger.debug(`${Logger.getFormattedCallerInformation()} ${message}`);
+        this.logger.debug(`${Logger.getFormattedCallerInformation()} ${message}`);
     }
 
     public static info(message: string) {
-        logger.info(`${Logger.getFormattedCallerInformation()} ${message}`);
+        this.logger.info(`${Logger.getFormattedCallerInformation()} ${message}`);
     }
 
     public static warn(message: string) {
-        logger.warn(`${Logger.getFormattedCallerInformation()} ${message}`);
+        this.logger.warn(`${Logger.getFormattedCallerInformation()} ${message}`);
     }
 
     public static error(message: string) {
-        logger.error(`${Logger.getFormattedCallerInformation()} ${message}`);
+        this.logger.error(`${Logger.getFormattedCallerInformation()} ${message}`);
     }
 
     public static deactivate() {
-        logger.dispose();
+        this.logger.dispose();
     }
 
     public static logSystemInformation() {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,7 @@
 import { window } from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
 
 export const loggerName = 'Manim Notebook';
 const logger = window.createOutputChannel(loggerName, { log: true });
@@ -24,6 +26,31 @@ export class Logger {
 
     public static error(message: string) {
         logger.error(`${Logger.getFormattedCallerInformation()} ${message}`);
+    }
+
+    public static deactivate() {
+        logger.dispose();
+    }
+
+    public static logSystemInformation() {
+        Logger.info(`Operating system: ${os.type()} ${os.release()} ${os.arch()}`);
+        Logger.info(`Process versions: ${JSON.stringify(process.versions)}`);
+
+        try {
+            const packageJsonPath = path.join(__dirname, '..', 'package.json');
+            const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+            const version = packageJson.version;
+            Logger.info(`Manim notebook version: ${version}`);
+        } catch (error: Error | unknown) {
+            Logger.info("Could not determine Manim notebook version used");
+            try {
+                Logger.error(String(error));
+            } catch {
+                Logger.error("(Unable not stringify the error message)");
+            }
+        }
+
+        Logger.info("--------------------------");
     }
 
     /**

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -163,3 +163,48 @@ export class Window {
         window.showErrorMessage(message);
     }
 }
+
+/**
+ * Opens the Manim Notebook log file in a new editor.
+ * 
+ * @param context The extension context.
+ */
+export function recordLogFile(context: vscode.ExtensionContext) {
+    const logFilePath = vscode.Uri.joinPath(context.logUri, `${loggerName}.log`);
+    window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: "Opening Manim Notebook log file...",
+        cancellable: false
+    }, async (progressIndicator, token) => {
+        await new Promise<void>(async (resolve) => {
+            try {
+                const doc = await vscode.workspace.openTextDocument(logFilePath);
+                await window.showTextDocument(doc);
+            } catch {
+                Window.showErrorMessage("Could not open Manim Notebook log file");
+            } finally {
+                resolve();
+            }
+
+            try {
+                await revealFileInOS(logFilePath);
+            } catch (error: any) {
+                window.showErrorMessage(`Could not open Manim Notebook log file in the`
+                    + ` OS file explorer: ${error?.message}`);
+            }
+        });
+    });
+}
+
+/**
+ * Opens a file in the OS file explorer.
+ * 
+ * @param uri The URI of the file to reveal.
+ */
+async function revealFileInOS(uri: vscode.Uri) {
+    if (vscode.env.remoteName === 'wsl') {
+        await vscode.commands.executeCommand('remote-wsl.revealInExplorer', uri);
+    } else {
+        await vscode.commands.executeCommand('revealFileInOS', uri);
+    }
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -187,7 +187,8 @@ export class LogRecorder {
     private static recorderStatusBar: vscode.StatusBarItem;
 
     /**
-     * Starts recording a log file.
+     * Starts recording a log file. Initializes a new status bar item that
+     * allows the user to stop the recording.
      * 
      * @param context The extension context.
      */
@@ -236,8 +237,8 @@ export class LogRecorder {
     }
 
     /**
-     * Finished the active recording of a log file. Called when the user
-     * clicks on the status bar item.
+     * Finishes the active recording of a log file. Called when the user
+     * clicks on the status bar item initialized in `recordLogFile()`.
      * 
      * @param context The extension context.
      */

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -42,7 +42,7 @@ export class Logger {
             const version = packageJson.version;
             Logger.info(`Manim notebook version: ${version}`);
         } catch (error: Error | unknown) {
-            Logger.info("Could not determine Manim notebook version used");
+            Logger.error("Could not determine Manim notebook version used");
             try {
                 Logger.error(String(error));
             } catch {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -16,22 +16,37 @@ export class Logger {
         LOGGER_NAME, { log: true });
 
     public static trace(message: string) {
+        if (!this.isRecording) {
+            return;
+        }
         this.logger.trace(`${Logger.getFormattedCallerInformation()} ${message}`);
     }
 
     public static debug(message: string) {
+        if (!this.isRecording) {
+            return;
+        }
         this.logger.debug(`${Logger.getFormattedCallerInformation()} ${message}`);
     }
 
     public static info(message: string) {
+        if (!this.isRecording) {
+            return;
+        }
         this.logger.info(`${Logger.getFormattedCallerInformation()} ${message}`);
     }
 
     public static warn(message: string) {
+        if (!this.isRecording) {
+            return;
+        }
         this.logger.warn(`${Logger.getFormattedCallerInformation()} ${message}`);
     }
 
     public static error(message: string) {
+        if (!this.isRecording) {
+            return;
+        }
         this.logger.error(`${Logger.getFormattedCallerInformation()} ${message}`);
     }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -46,7 +46,7 @@ export class Logger {
             try {
                 Logger.error(String(error));
             } catch {
-                Logger.error("(Unable not stringify the error message)");
+                Logger.error("(Unable to stringify the error message)");
             }
         }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -197,6 +197,7 @@ export class LogRecorder {
             window.showInformationMessage("A log file is already being recorded.");
             return;
         }
+        Logger.isRecording = true;
 
         let isClearSuccessful = false;
 
@@ -215,6 +216,7 @@ export class LogRecorder {
         });
 
         if (!isClearSuccessful) {
+            Logger.isRecording = false;
             return;
         }
 
@@ -223,8 +225,6 @@ export class LogRecorder {
         this.recorderStatusBar.command = "manim-notebook.finishRecordingLogFile";
         this.recorderStatusBar.backgroundColor = new vscode.ThemeColor(
             'statusBarItem.errorBackground');
-
-        Logger.isRecording = true;
 
         // Right now, there is no way to set the log level programatically.
         // We can just show the pop-up to do so to users.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -182,7 +182,7 @@ export class LogRecorder {
      */
     public static async recordLogFile(context: vscode.ExtensionContext) {
         if (Logger.isRecording) {
-            window.showWarningMessage("A log file is already being recorded.");
+            window.showInformationMessage("A log file is already being recorded.");
             return;
         }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -203,15 +203,17 @@ export class LogRecorder {
 
         await window.withProgress({
             location: vscode.ProgressLocation.Notification,
-            title: "Setting everything up for Log recording...",
+            title: "Setting up Manim Notebook Log recording...",
             cancellable: false
         }, async (progressIndicator, token) => {
             try {
                 await Logger.clear(this.getLogFilePath(context));
                 isClearSuccessful = true;
             } catch (error: any) {
-                window.showErrorMessage(`Try to reload your VSCode window, then try again.`
-                    + ` We were not able to set up a log file: ${error?.message}`);
+                window.showErrorMessage(
+                    `Please reload your VSCode window to set up the log file: ` +
+                    `Command palette -> "Developer: Reload Window". ` +
+                    `Then try logging again. Current error: ${error?.message}`);
             }
         });
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -55,7 +55,7 @@ export class Logger {
         try {
             await waitUntilFileExists(logFilePath.fsPath, 3000);
             Logger.info(`📜 Logfile found and cleared at ${new Date().toISOString()}`);
-        } catch (error: any){
+        } catch (error: any) {
             Logger.error(`Could not clear logfile: ${error?.message}`);
         }
     }
@@ -171,7 +171,16 @@ export class Window {
  */
 export function recordLogFile(context: vscode.ExtensionContext) {
     const logFilePath = vscode.Uri.joinPath(context.logUri, `${loggerName}.log`);
-    window.withProgress({
+    openLogFile(logFilePath);
+}
+
+/**
+ * Tries to open the log file in an editor and reveal it in the OS file explorer.
+ * 
+ * @param logFilePath The URI of the log file.
+ */
+async function openLogFile(logFilePath: vscode.Uri) {
+    await window.withProgress({
         location: vscode.ProgressLocation.Notification,
         title: "Opening Manim Notebook log file...",
         cancellable: false
@@ -180,17 +189,12 @@ export function recordLogFile(context: vscode.ExtensionContext) {
             try {
                 const doc = await vscode.workspace.openTextDocument(logFilePath);
                 await window.showTextDocument(doc);
-            } catch {
-                Window.showErrorMessage("Could not open Manim Notebook log file");
-            } finally {
-                resolve();
-            }
-
-            try {
                 await revealFileInOS(logFilePath);
             } catch (error: any) {
-                window.showErrorMessage(`Could not open Manim Notebook log file in the`
-                    + ` OS file explorer: ${error?.message}`);
+                window.showErrorMessage(`Could not open Manim Notebook log file:`
+                    + ` ${error?.message}`);
+            } finally {
+                resolve();
             }
         });
     });


### PR DESCRIPTION
Fixes #58. Fixes #60.

In this PR, we pimp up the logging mechanism and introduce the concept of a "Logging session", i.e. users can start a logging session. When ending it, the log file will automatically open. Please make sure the [updated steps of the Troubleshooting section](https://github.com/bhoov/manim-notebook/tree/fix/logger-reloading-and-version?tab=readme-ov-file#troubleshooting) work for you with this PR.

![image](https://github.com/user-attachments/assets/e6ed6bee-3955-418b-afe0-0cdd2c93a993)


When reviewing, please make sure that the following works additionally:
- [x] After you exit the logging session, the log file should be shown in the VSCode editor, as well as in your OS explorer, e.g. the Windows Explorer or MacOS Finder. This allows users to just drag and drop that file (and not the file content) into a new GitHub issue).
- [x] After having recorded one logging sessions, when you start a new one and stop it, you should only see the log messages from the second sessions. That is, the log file should be cleared before every log session start.
- [x] When you start a logging session while one is already running, an information message should be shown.
- [x] Try the following: record a log session, then end it. Your OS explorer should show the log file. Then manually delete this log file. Now try to start a new log session and an error should show proposing you to restart the VSCode window. After doing to, everything should work normally again (-> try to start and end another logging session).
- [x] Record and end a log session. Keep the log file open. Now do something else with Manim and the logger shouldn't write anything to the log file. It should only append to it whenever we record a log session.
