### PR TITLE
Fix IPython cell detection (multiple ones in one datastream)

### DIFF
--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -529,7 +529,7 @@ export class ManimShell {
                         this.eventEmitter.emit(ManimShellEvent.KEYBOARD_INTERRUPT);
                     }
 
-                    let ipythonMatches = lol.match(IPYTHON_CELL_START_REGEX);
+                    let ipythonMatches = data.match(IPYTHON_CELL_START_REGEX);
                     if (ipythonMatches) {
                         // Terminal data might include multiple IPython statements,
                         // so take the highest cell number found.

--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -15,7 +15,7 @@ const ANSI_CONTROL_SEQUENCE_REGEX = /(?:\x1B[@-Z\\-_]|[\x80-\x9A\x9C-\x9F]|(?:\x
 /**
  * Regular expression to match the start of an IPython cell, e.g. "In [5]:"
  */
-const IPYTHON_CELL_START_REGEX = /^\s*In \[\d+\]:/m;
+const IPYTHON_CELL_START_REGEX = /^\s*In \[\d+\]:/gm;
 
 /**
  * Regular expression to match a KeyboardInterrupt.
@@ -529,11 +529,15 @@ export class ManimShell {
                         this.eventEmitter.emit(ManimShellEvent.KEYBOARD_INTERRUPT);
                     }
 
-                    let ipythonMatch = data.match(IPYTHON_CELL_START_REGEX);
-                    if (ipythonMatch) {
-                        const cellNumber = parseInt(ipythonMatch[0].match(/\d+/)![0]);
-                        this.iPythonCellCount = cellNumber;
-                        Logger.debug(`📦 IPython cell ${cellNumber} detected`);
+                    let ipythonMatches = lol.match(IPYTHON_CELL_START_REGEX);
+                    if (ipythonMatches) {
+                        // Terminal data might include multiple IPython statements,
+                        // so take the highest cell number found.
+                        const cellNumbers = ipythonMatches.map(
+                            match => parseInt(match.match(/\d+/)![0]));
+                        const maxCellNumber = Math.max(...cellNumbers);
+                        this.iPythonCellCount = maxCellNumber;
+                        Logger.debug(`📦 IPython cell ${maxCellNumber} detected`);
                         this.eventEmitter.emit(ManimShellEvent.IPYTHON_CELL_FINISHED);
                     }
 


### PR DESCRIPTION
This fixes #52. At least I hope I've fixed the problem identified by @VladimirFokow in the [first log](https://github.com/bhoov/manim-notebook/issues/52#issuecomment-2448568959). Please tell me if this PR also fixes the other problems of that issue. If not, I will take a look at them as well.

The issue could be identified by comparing logs on different machines. Here only the most relevant parts:

<details>

<summary>On Linux (WSL)</summary>


```
2024-10-31 10:49:18.109 [trace] [manimShell.ts:514:28] [unknown] 🧾 Terminal data:
In [1]:  checkpoint_paste()In [1]:  checkpoint_paste()


2024-10-31 10:49:18.109 [debug] [manimShell.ts:536:32] [unknown] 📦 IPython cell 1 detected
2024-10-31 10:49:18.109 [debug] [manimShell.ts:475:24] [unknown] 🕒 While waiting for command to finish, iPythonCellCount=1, currentExecutionCount=1
2024-10-31 10:49:18.109 [debug] [manimShell.ts:475:24] [unknown] 🕒 While waiting for command to finish, iPythonCellCount=1, currentExecutionCount=1
2024-10-31 10:49:18.474 [trace] [manimShell.ts:514:28] [unknown] 🧾 Terminal data:
1
2

In [2]: In [2]: 

















































 
2024-10-31 10:49:18.474 [debug] [manimShell.ts:536:32] [unknown] 📦 IPython cell 2 detected
```

</details>


<details>

<summary>On MacOS</summary>


```
2024-10-30 23:20:39.611 [trace] [manimShell.ts:514:28] [unknown] 🧾 Terminal data:
In [1]:  checkpoint_paste()

































 In [1]:  checkpoint_paste()

1
2

In [2]: In [2]: 

























 
2024-10-30 23:20:39.612 [debug] [manimShell.ts:536:32] [unknown] 📦 IPython cell 1 detected
2024-10-30 23:20:39.612 [debug] [manimShell.ts:475:24] [unknown] 🕒 While waiting for command to finish, iPythonCellCount=1, currentExecutionCount=1
```

</details>

See the difference? On Linux I get two separate data streams and each one only contains one IPython Cell identifier. This is not the case for MacOS. Therefore, I changed the RegEx to globally match multiple occurrences in a data stream and then just take the maximum number I have found, in this example: 2.


Note the fixed approach is coherent with

https://github.com/bhoov/manim-notebook/blob/b4ec9bbe242a3d120d2674091c046f1962f29809/src/manimShell.ts#L478

since this will evaluate to true if the seen cell count is higher than the current cell count. So even if we skip over cells via this new tactic, we will definitely end the old ones when a cell higher than the current execution count is seen.