### PR TITLE
Reset isExecutingCommand during shell reset

### DIFF
--- a/src/manimShell.ts
+++ b/src/manimShell.ts
@@ -357,6 +357,7 @@ export class ManimShell {
     */
     public resetActiveShell() {
         Logger.debug("💫 Reset active shell");
+        this.isExecutingCommand = false;
         this.iPythonCellCount = 0;
         this.activeShell = null;
         this.shellWeTryToSpawnIn = null;


### PR DESCRIPTION
Fixes #53.

I didn't encounter this situation since we set `shouldLockDuringCommandExecution` to true only for Mac, that's why we experienced the different behavior here. I forgot to reset the `isExecutingCommand` flag during the shell reset.