### PR TITLE
fix: Use shallow copy before reversing

### DIFF
--- a/src/pythonParsing.ts
+++ b/src/pythonParsing.ts
@@ -325,6 +325,6 @@ export class ManimClass {
   public static getManimClassAtCursor(document: TextDocument, cursorLine: number):
   ManimClass | undefined {
     const manimClasses = this.findAllIn(document);
-    return manimClasses.reverse().find(({ lineNumber }) => lineNumber <= cursorLine);
+    return manimClasses.slice().reverse().find(({ lineNumber }) => lineNumber <= cursorLine);
   }
 }


### PR DESCRIPTION
Fixes #140.

**Problem**  
`getManimClassAtCursor` directly calls `reverse()` on the array returned from `findAllIn`, which modifies the cached array. This causes the array order to change after the first call, leading to incorrect results on subsequent calls.  

**Fix**  
Replace `manimClasses.reverse().find(...)` with `manimClasses.slice().reverse().find(...)`.  
- `slice()` creates a shallow copy of the original array.  
- The reversal is applied to the copy, leaving the cached array unchanged.  
- The `find` operation works on the temporary copy, preserving the original order for future calls.
